### PR TITLE
Fix broken URL to project repository

### DIFF
--- a/core-dev-guide.md
+++ b/core-dev-guide.md
@@ -1,7 +1,7 @@
 Core Developer Guidelines
 =========================
 These guidelines apply to the core developers, i.e., those with write
-(push) access to the [cloudmarker/cloudmarker](cmrepo) repo.
+(push) access to the [cloudmarker/cloudmarker][repo] repo.
 
 [repo]: https://github.com/cloudmarker/cloudmarker
 


### PR DESCRIPTION
See https://github.com/cloudmarker/guides/blob/fix-ref/core-dev-guide.md to check the rendered document. The broken URL now appears to be fixed.